### PR TITLE
refactor: Conditionally compile `Send` bounds instead of `SendWrapper`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,6 @@ dependencies = [
  "multihash-codetable",
  "rexie",
  "rstest",
- "send_wrapper",
  "sled",
  "tempfile",
  "thiserror",
@@ -912,15 +911,6 @@ name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
-
-[[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "sha1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { version = "1.29.0", features = ["macros", "rt"], optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.68", optional = true }
 rexie = { version = "0.5.0", optional = true }
-send_wrapper = { version = "0.6.0", features = ["futures"], optional = true }
 wasm-bindgen = { version = "0.2.91", optional = true }
 
 [dev-dependencies]
@@ -48,7 +47,7 @@ wasm-bindgen-test = "0.3.41"
 [features]
 lru = ["dep:lru"]
 sled = ["dep:sled", "dep:tokio"]
-indexeddb = ["dep:js-sys", "dep:rexie", "dep:send_wrapper", "dep:wasm-bindgen"]
+indexeddb = ["dep:js-sys", "dep:rexie", "dep:wasm-bindgen"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docs_rs"]

--- a/src/cond_send.rs
+++ b/src/cond_send.rs
@@ -1,0 +1,33 @@
+//! Utilities for conditionally adding `Send` and `Sync` constraints.
+
+/// A conditionally compiled trait indirection for `Send` bounds.
+/// This target makes it require `Send`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait CondSend: Send {}
+
+/// A conditionally compiled trait indirection for `Send` bounds.
+/// This target makes it not require any marker traits.
+#[cfg(target_arch = "wasm32")]
+pub trait CondSend {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> CondSend for S where S: Send {}
+
+#[cfg(target_arch = "wasm32")]
+impl<S> CondSend for S {}
+
+/// A conditionally compiled trait indirection for `Send + Sync` bounds.
+/// This target makes it require `Send + Sync`.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait CondSync: Send + Sync {}
+
+/// A conditionally compiled trait indirection for `Send + Sync` bounds.
+/// This target makes it not require any marker traits.
+#[cfg(target_arch = "wasm32")]
+pub trait CondSync {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> CondSync for S where S: Send + Sync {}
+
+#[cfg(target_arch = "wasm32")]
+impl<S> CondSync for S {}


### PR DESCRIPTION
Closes #2 

Happy to discuss this PR.

There's two ways to do async traits in wasm/browsers, where most things are `!Send`:
- Use normal traits that require `Send` bounds, but use `SendWrapper` in the browser implementations (this has been the case so far)
- Conditionally compile `Send` bounds, depending on whether the target is `wasm32` or not.

Both approaches have pros and cons. With `CondSend` you have one less dependency to argue over and the code is easier to read, but conditionally compiling on `target_arch` is somewhat arbitrary. One could argue that it should be a feature flag instead, etc.

Happy to discuss. I don't expect this to be merged, but would currently argue in favor of that. The alternative for us would be introducing `sendwrapper` into `wnfs-wasm` and `car-mirror-wasm` implementations, which isn't the end of the world.