### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.1](https://github.com/eigerco/blockstore/compare/v0.3.0...v0.3.1) - 2024-04-03
+## [0.4.0](https://github.com/eigerco/blockstore/compare/v0.3.0...v0.4.0) - 2024-04-03
 
 ### Other
 - Conditionally compile `Send` bounds instead of `SendWrapper` ([#8](https://github.com/eigerco/blockstore/pull/8))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/eigerco/blockstore/compare/v0.3.0...v0.3.1) - 2024-04-03
+
+### Other
+- Conditionally compile `Send` bounds instead of `SendWrapper` ([#8](https://github.com/eigerco/blockstore/pull/8))
+
 ## [0.3.0](https://github.com/eigerco/blockstore/compare/v0.2.0...v0.3.0) - 2024-03-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cid",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cid",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.3.0 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/eigerco/blockstore/compare/v0.3.0...v0.4.0) - 2024-04-03

### Other
- Conditionally compile `Send` bounds instead of `SendWrapper` ([#8](https://github.com/eigerco/blockstore/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).