### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/eigerco/blockstore/compare/v0.4.0...v0.5.0) - 2024-04-15
+
+### Added
+- [**breaking**] Rename `BlockstoreError` to `Error` ([#17](https://github.com/eigerco/blockstore/pull/17))
+- Implement `RedbBlockstore` ([#12](https://github.com/eigerco/blockstore/pull/12))
+- [**breaking**] Add `BlockstoreError::ValueTooLarge` ([#15](https://github.com/eigerco/blockstore/pull/15))
+- [**breaking**] Rename `BlockstoreError::CidTooLong` to `BlockstoreError::CidTooLarge` ([#14](https://github.com/eigerco/blockstore/pull/14))
+- [**breaking**] Refine error `BlockstoreError` variants ([#11](https://github.com/eigerco/blockstore/pull/11))
+
+### Other
+- Polish before release ([#16](https://github.com/eigerco/blockstore/pull/16))
+
 ## [0.4.0](https://github.com/eigerco/blockstore/compare/v0.3.0...v0.4.0) - 2024-04-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cid",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.4.0 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `blockstore` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_missing.ron

Failed in:
  enum blockstore::BlockstoreError, previously in file /tmp/.tmp2NfgqJ/blockstore/src/lib.rs:37
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/eigerco/blockstore/compare/v0.4.0...v0.5.0) - 2024-04-15

### Added
- [**breaking**] Rename `BlockstoreError` to `Error` ([#17](https://github.com/eigerco/blockstore/pull/17))
- Implement `RedbBlockstore` ([#12](https://github.com/eigerco/blockstore/pull/12))
- [**breaking**] Add `BlockstoreError::ValueTooLarge` ([#15](https://github.com/eigerco/blockstore/pull/15))
- [**breaking**] Rename `BlockstoreError::CidTooLong` to `BlockstoreError::CidTooLarge` ([#14](https://github.com/eigerco/blockstore/pull/14))
- [**breaking**] Refine error `BlockstoreError` variants ([#11](https://github.com/eigerco/blockstore/pull/11))

### Other
- Polish before release ([#16](https://github.com/eigerco/blockstore/pull/16))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).