### PR TITLE
feat: add missing store impls & add `len`

### DIFF
--- a/src/in_memory_blockstore.rs
+++ b/src/in_memory_blockstore.rs
@@ -4,6 +4,7 @@ use dashmap::DashMap;
 use crate::{convert_cid, Blockstore, Result};
 
 /// Simple in-memory blockstore implementation.
+#[derive(Clone, Debug)]
 pub struct InMemoryBlockstore<const MAX_MULTIHASH_SIZE: usize> {
     map: DashMap<CidGeneric<MAX_MULTIHASH_SIZE>, Vec<u8>>,
 }
@@ -14,6 +15,16 @@ impl<const MAX_MULTIHASH_SIZE: usize> InMemoryBlockstore<MAX_MULTIHASH_SIZE> {
         InMemoryBlockstore {
             map: DashMap::new(),
         }
+    }
+
+    /// Get the number of elements in the blockstore
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Check if the blockstore is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     fn get_cid(&self, cid: &CidGeneric<MAX_MULTIHASH_SIZE>) -> Result<Option<Vec<u8>>> {

--- a/src/lru_blockstore.rs
+++ b/src/lru_blockstore.rs
@@ -6,6 +6,7 @@ use lru::LruCache;
 use crate::{convert_cid, Blockstore, Result};
 
 /// An LRU cached [`Blockstore`].
+#[derive(Debug)]
 pub struct LruBlockstore<const MAX_MULTIHASH_SIZE: usize> {
     cache: Mutex<LruCache<CidGeneric<MAX_MULTIHASH_SIZE>, Vec<u8>>>,
 }
@@ -16,6 +17,16 @@ impl<const MAX_MULTIHASH_SIZE: usize> LruBlockstore<MAX_MULTIHASH_SIZE> {
         LruBlockstore {
             cache: Mutex::new(LruCache::new(capacity)),
         }
+    }
+
+    /// Get the number of elements in the blockstore
+    pub fn len(&self) -> usize {
+        self.cache.lock().expect("lock failed").len()
+    }
+
+    /// Check if the blockstore is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 


### PR DESCRIPTION
Hey folks!

I've been refactoring a library to use `Blockstore` instead of my bespoke library-internal one, and found that it was difficult to test and debug a couple things. I've added a few `impl`s (where possible), plus `len` so that I can ensure some of my storage tests are exhaustive.

* `InMemoryBlockstore`
  * Traits: add `Clone` and `Debug`
  * Functions: add `len`
* `LruBlockstore`
  * Traits: add `Debug`
  * Functions: add `len`

It _might_ make sense to put that `len` on the `Blockstore` trait, but I figured on the lightest stores which have underlying `len`s was the most conservative approach for now.

Please let me know if I can add anything else, or if you'd like any changes :)