### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [**breaking**] Add `remove` method ([#18](https://github.com/eigerco/blockstore/pull/18))
 
 ### Fixed
-- *(doc)* rename doc_cfg guard to docsrs, rust-lang/cargo[#13875](https://github.com/eigerco/blockstore/pull/13875) ([#20](https://github.com/eigerco/blockstore/pull/20))
+- *(doc)* rename doc_cfg guard to docsrs, [rust-lang/cargo#13875](https://github.com/rust-lang/cargo/issues/13875) ([#20](https://github.com/eigerco/blockstore/pull/20))
 
 ## [0.5.0](https://github.com/eigerco/blockstore/compare/v0.4.0...v0.5.0) - 2024-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/eigerco/blockstore/compare/v0.5.0...v0.6.0) - 2024-06-27
+
+### Added
+- add missing store impls & add `len` ([#21](https://github.com/eigerco/blockstore/pull/21))
+- [**breaking**] Add `remove` method ([#18](https://github.com/eigerco/blockstore/pull/18))
+
+### Fixed
+- *(doc)* rename doc_cfg guard to docsrs, rust-lang/cargo[#13875](https://github.com/eigerco/blockstore/pull/13875) ([#20](https://github.com/eigerco/blockstore/pull/20))
+
 ## [0.5.0](https://github.com/eigerco/blockstore/compare/v0.4.0...v0.5.0) - 2024-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cid",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.5.0 -> 0.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/eigerco/blockstore/compare/v0.5.0...v0.6.0) - 2024-06-27

### Added
- add missing store impls & add `len` ([#21](https://github.com/eigerco/blockstore/pull/21))
- [**breaking**] Add `remove` method ([#18](https://github.com/eigerco/blockstore/pull/18))

### Fixed
- *(doc)* rename doc_cfg guard to docsrs, rust-lang/cargo[#13875](https://github.com/eigerco/blockstore/pull/13875) ([#20](https://github.com/eigerco/blockstore/pull/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).