### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/eigerco/blockstore/compare/v0.6.0...v0.6.1) - 2024-08-13
+
+### Fixed
+- *(indexeddb)* Abort failed transactions ([#27](https://github.com/eigerco/blockstore/pull/27))
+
+### Other
+- Update README.md ([#26](https://github.com/eigerco/blockstore/pull/26))
+- Update rexie and other misc dependencies ([#24](https://github.com/eigerco/blockstore/pull/24))
+
 ## [0.6.0](https://github.com/eigerco/blockstore/compare/v0.5.0...v0.6.0) - 2024-06-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cid",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.6.0 -> 0.6.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/eigerco/blockstore/compare/v0.6.0...v0.6.1) - 2024-08-13

### Fixed
- *(indexeddb)* Abort failed transactions ([#27](https://github.com/eigerco/blockstore/pull/27))

### Other
- Update README.md ([#26](https://github.com/eigerco/blockstore/pull/26))
- Update rexie and other misc dependencies ([#24](https://github.com/eigerco/blockstore/pull/24))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).