### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/eigerco/blockstore/compare/v0.6.1...v0.7.0) - 2024-09-10
+
+### Added
+
+- [**breaking**] Add `Blockstore::close` method ([#29](https://github.com/eigerco/blockstore/pull/29))
+
+### Fixed
+
+- Remove unneded idb dependency ([#30](https://github.com/eigerco/blockstore/pull/30))
+
 ## [0.6.1](https://github.com/eigerco/blockstore/compare/v0.6.0...v0.6.1) - 2024-08-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "blockstore"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "cid",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockstore"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "An IPLD blockstore capable of holding arbitrary data indexed by CID"


### PR DESCRIPTION
## 🤖 New release
* `blockstore`: 0.6.1 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/eigerco/blockstore/compare/v0.6.1...v0.7.0) - 2024-09-10

### Added

- [**breaking**] Add `Blockstore::close` method ([#29](https://github.com/eigerco/blockstore/pull/29))

### Fixed

- Remove unneded idb dependency ([#30](https://github.com/eigerco/blockstore/pull/30))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).